### PR TITLE
FIO-9173: Allow Scientific Notations by Default

### DIFF
--- a/addons/src/createNumberMask.js
+++ b/addons/src/createNumberMask.js
@@ -21,7 +21,7 @@ export default function createNumberMask({
   allowNegative = false,
   allowLeadingZeroes = false,
   integerLimit = null,
-  allowScientificNotation = false,
+  allowScientificNotation = true,
 } = {}) {
   const prefixLength = prefix && prefix.length || 0
   const suffixLength = suffix && suffix.length || 0


### PR DESCRIPTION
## What changed 
We switched the property to "true" to act like a regular number component and allow scientific notation by default